### PR TITLE
Fix build script to run correct shell

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#/bin/sh
+#!/bin/sh
 set -e
 mvn clean install
 mvn -f plugins/idea/pom.xml clean install


### PR DESCRIPTION
The build script has a malformed first line, so can't be run as a command if the current shell is not sh or bash.